### PR TITLE
make the mapping configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,36 @@ This Vim plugin makes text objects with various elixir block structures.
 Many end-terminated blocks are parsed using regex, indentation and syntax
 highlight.  This is more correct than parsing text with regex only.
 
-## Simple one operator-pending mapping `e`
+## Configuration
 
-Elixir text objects include: 'setup_all', 'setup', 'describe', 'test',
-'unless', 'quote', 'case', 'cond', 'when', 'with', 'for', 'if',
-'defprotocol', 'defmodule', 'defmacro', 'defmacrop', 'defimpl', 'defp',
-'def'.
+By default this motion is mapped to 'e'.  The key mapping can be overridden by adding a line similar to this to your vimrc:
+
+```vim
+let g:vim_textobj_elixir_mapping = 'e'
+```
+
+## Usage
+
+Elixir text objects include:
+- `case`
+- `cond`
+- `def`
+- `defimpl`
+- `defmacro`
+- `defmacrop`
+- `defmodule`
+- `defp`
+- `defprotocol`
+- `describe`
+- `for`
+- `if`
+- `quote`
+- `setup`
+- `setup_all`
+- `test`
+- `unless`
+- `when`
+- `with`
 
 Example:
 

--- a/plugin/textobj/elixir.vim
+++ b/plugin/textobj/elixir.vim
@@ -7,8 +7,8 @@ if !exists('g:vim_textobj_elixir_mapping')
   let g:vim_textobj_elixir_mapping = 'e'
 endif
 
-let s:save_cpo = &cpoptions
-set cpoptions&vim
+let s:save_cpo = &cpo
+set cpo&vim
 
 call textobj#user#plugin('elixir', {
     \ 'any' : {
@@ -17,5 +17,5 @@ call textobj#user#plugin('elixir', {
     \   },
     \ })
 
-let &cpoptions = s:save_cpo
+let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/textobj/elixir.vim
+++ b/plugin/textobj/elixir.vim
@@ -3,15 +3,19 @@ if exists('g:loaded_textobj_elixir_plugin')
 endif
 let g:loaded_textobj_elixir_plugin = 1
 
-let s:save_cpo = &cpo
-set cpo&vim
+if !exists('g:vim_textobj_elixir_mapping')
+  let g:vim_textobj_elixir_mapping = 'e'
+endif
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
 
 call textobj#user#plugin('elixir', {
     \ 'any' : {
-    \      'select-a' : 'ae', '*select-a-function*' : 'textobj#elixir#any_select_a',
-    \      'select-i' : 'ie', '*select-i-function*' : 'textobj#elixir#any_select_i',
+    \      'select-a' : 'a' . g:vim_textobj_elixir_mapping, '*select-a-function*' : 'textobj#elixir#any_select_a',
+    \      'select-i' : 'i' . g:vim_textobj_elixir_mapping, '*select-i-function*' : 'textobj#elixir#any_select_i',
     \   },
     \ })
 
-let &cpo = s:save_cpo
+let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
The default mapping conflicts with [kana/vim-textobj-entire](https://github.com/kana/vim-textobj-entire), so I used [sgur/vim-textobj-parameter](https://github.com/sgur/vim-textobj-parameter) as a reference to implement a configurable motion while keeping the `e` default.